### PR TITLE
feat: allow Wrapper to be used with tagName prop

### DIFF
--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -58,11 +58,12 @@ class Wrapper extends React.PureComponent {
 
   render() {
     this.calculateProps();
-    const TagName = this.TagName;
-    return (
-      <TagName ref={this.ref} {...this.normalProps}>
-        {this.props.children}
-      </TagName>
+    return React.createElement(
+      this.TagName || this.props.tagName, 
+      {
+        ref: this.ref,
+        ...this.normalProps
+      }
     );
   }
 }


### PR DESCRIPTION
I know the Wrapper is not done yet, but I thought this change might be nice regardless:

## Before

```jsx
import Wrapper from './wrapper';
class OdsButton extends Wrapper {
    TagName = 'ods-button'
}

<OdsButton buttonCallback={click} buttontype={type}>Hello World</OdsButton>
```

## After

```jsx
import Wrapper from './wrapper';
class OdsButton extends Wrapper {
    TagName = 'ods-button'
}

<OdsButton buttonCallback={click}>Hello World</OdsButton>
```

or

```jsx
import OdsWrapper from './wrapper';

<OdsWrapper tagName="ods-button" buttonCallback={click}>Hello World</OdsButton>
```

## Screenshots

Here's a screenshot of it still rendering, for what it's worth:
![image](https://user-images.githubusercontent.com/14362200/69099619-0a7dea00-0a10-11ea-8cb3-f855f2fb9a0d.png)
